### PR TITLE
Fix return type of CrFwGetCurrentTime()

### DIFF
--- a/src/CrConfigDemoMaster/CrFwTime.c
+++ b/src/CrConfigDemoMaster/CrFwTime.c
@@ -42,7 +42,7 @@ CrFwTimeStamp_t CrFwGetCurrentTimeStamp() {
 }
 
 /*-----------------------------------------------------------------------------------------*/
-CrFwTime_t CrFwGetCurrentTime() {
+CrFwTimeStamp_t CrFwGetCurrentTime() {
 	return dummyTime;
 }
 

--- a/src/CrConfigDemoSlave1/CrFwTime.c
+++ b/src/CrConfigDemoSlave1/CrFwTime.c
@@ -42,7 +42,7 @@ CrFwTimeStamp_t CrFwGetCurrentTimeStamp() {
 }
 
 /*-----------------------------------------------------------------------------------------*/
-CrFwTime_t CrFwGetCurrentTime() {
+CrFwTimeStamp_t CrFwGetCurrentTime() {
 	return dummyTime;
 }
 

--- a/src/CrConfigDemoSlave2/CrFwTime.c
+++ b/src/CrConfigDemoSlave2/CrFwTime.c
@@ -42,7 +42,7 @@ CrFwTimeStamp_t CrFwGetCurrentTimeStamp() {
 }
 
 /*-----------------------------------------------------------------------------------------*/
-CrFwTime_t CrFwGetCurrentTime() {
+CrFwTimeStamp_t CrFwGetCurrentTime() {
 	return dummyTime;
 }
 


### PR DESCRIPTION
When building on Ubuntu 18.04 with `gcc` version 7.4.0, the compilation of `cordetfw-examples` fails with
```
====================================================================================
 Compile the C2 Configuration Files for the Master Application 
====================================================================================
./src//CrConfigDemoMaster/CrFwTime.c:45:12: error: conflicting types for ‘CrFwGetCurrentTime’
 CrFwTime_t CrFwGetCurrentTime() {
            ^~~~~~~~~~~~~~~~~~
In file included from ./src//CrConfigDemoMaster/CrFwTime.c:33:0:
./lib/cordetfw/src/CrFwTime.h:39:17: note: previous declaration of ‘CrFwGetCurrentTime’ was here
 CrFwTimeStamp_t CrFwGetCurrentTime();
                 ^~~~~~~~~~~~~~~~~~
```

The declaration of `CrFwGetCurrentTime()` in `CrFwTime.h` and the defintion in the master and slave applications do not match -- they differ in the return type: `CrFwTimeStamp_t` vs. `CrFwTime_t`.

This PR just changes the return types of the definitions in the example files to match them with the declaration in `cordetfw`.

The variable `dummyTime`, which is returned in the definitions of `CrFwGetCurrentTime()`, has also the type `CrFwTimeStamp_t`, so this change should be fine here.
